### PR TITLE
Add issue target version id to notifier.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Whatever::Application.config.middleware.use ExceptionNotification::Rack,
   # assigned_to_id: create issues which are assigned to the given user_id
   # priority_id: create issues with the given priority_id
   # status_id: create issues with the given status_id
+  # fixed_version_id: create issues with the given fixed_version_id (aka target version id)
   # x_checksum_cf_id: custom field used to avoid creation of the same issue multiple times. You must use the DOM id assigned by Redmine to this field in the issue form. You can find it by creating an issue manually in your project and inspecting the HTML form, you should see something like name="issue[custom_field_values][19]", in this case the id would be 19.
   
   :redmine => {
@@ -51,6 +52,7 @@ Whatever::Application.config.middleware.use ExceptionNotification::Rack,
     :assigned_to_id => "123",
     :priority_id => "6", # Urgent
     :status_id => "1", # New
+    :fixed_version_id => "1", # id of the issue target version on redmine
     :x_checksum_cf_id => "19" # DOM id in Redmine issue form
   }
 ```

--- a/lib/exception_notifier/redmine/redmine.rb
+++ b/lib/exception_notifier/redmine/redmine.rb
@@ -46,6 +46,7 @@ module ExceptionNotifier
       issue[:status_id] = @config[:status_id]
       issue[:priority_id] = @config[:priority_id]
       issue[:assigned_to_id] = @config[:assigned_to_id]
+      issue[:fixed_version_id] = @config[:fixed_version_id]
       issue[:subject] = compose_subject
       issue[:custom_fields] = [{ :id    => @config[:x_checksum_cf_id],
                                  :value => encode_subject(issue[:subject])}]


### PR DESCRIPTION
- allows adding the fixed_version_id on the configuration file;
- passes this fixed_version_id to Redmine REST API when creating an issue.
