### PR TITLE
Add Markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Version 0.3.3
+- Update Licence(Please note this does not change the base copyright just modifications made by myself and is still licenced under the MIT licence)
+- Add Markdown Support(Defaults to markdown. If you want to keep redcloth please see the README)
+- Add Updating issues so that more information is provided rather than just being quiet(Optional)
+- Update README
+
 ### Version 0.3.2
 - Add Codeclimate badge
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### Version 0.3.3
-- Update Licence(Please note this does not change the base copyright just modifications made by myself and is still licenced under the MIT licence)
+- Update License(Please note this does not change the base copyright just modifications made by myself and is still licensed under the MIT license)
 - Add Markdown Support(Defaults to markdown. If you want to keep redcloth please see the README)
 - Add Updating issues so that more information is provided rather than just being quiet(Optional)
 - Update README

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2014 Nuxos Asia - richard.piacentini@nuxos.asia
+Copyright (c) 2019 Geoff Evans(For modifications made to the base GEM. Check https://github.com/geocom/exception_notification-redmine/commits to find the code that applies under this copyright.) - gbeevans@gmail.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +20,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -4,15 +4,19 @@ This gem add a Redmine notifier to Exception Notification.
 
 This Ruby gem is an extension of the [exception_notification gem](http://rubygems.org/gems/exception_notification) to support creating issues in Redmine.
 
-[![Gem Version](https://badge.fury.io/rb/exception_notification-redmine.svg)](http://badge.fury.io/rb/exception_notification-redmine)
-[![Code Climate](https://codeclimate.com/repos/58e48dd2516c00025a0010f7/badges/5d0990208e8564efc2ed/gpa.svg)](https://codeclimate.com/repos/58e48dd2516c00025a0010f7/feed)
+## Fork notice.
+This fork exists as a updated version of the [http://rubygems.org/gems/exception_notification-redmine](http://rubygems.org/gems/exception_notification-redmine) gem.
+I have attempted to contact the original developer to add these changes however this has been unsuccessful.
+The devs have been inactive for a few years and the companies website is now dead so assuming the original project will not be maintained.
+
+As this is a gem I use I am looking at taking over development. At present there is no build on rubygems. You will need to install directly from this fork. Installation instructions have been updated to this end.
 
 ## Installation
 
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'exception_notification-redmine'
+gem 'exception_notification-redmine', :git => 'https://github.com/geocom/exception_notification-redmine.git'
 ```
 
 And then execute:
@@ -20,14 +24,18 @@ And then execute:
     $ bundle
 
 Or install it yourself as:
-
-    $ gem install exception_notification-redmine
+    $ git clone https://github.com/geocom/exception_notification-redmine.git
+    $ cd exception_notification-redmine
+    $ rake gem
+    $ gem install pkg/exception_notification-redmine-<version>.gem
 
 ## Usage
 
 **IMPORTANT:** You must create a custom field named `x_checksum` in your Redmine project for the Redmine notifier to work properly
+**IMPORTANT FOR OPTIONAL SETTING:** To enable the hit counter you must add `x_hit_count` in your Redmine project for the Redmine notifier to work properly with updating an existing issue
+**IMPORTANT FOR OPTIONAL SETTING:** You must add a wontfix status if you enable reopening of closed issues.
 
-As of Rails 3 ExceptionNotification-Redmine is used as a rack middleware, or in the environment you want it to run. In most cases you would want ExceptionNotification-Redmine to run on production. Thus, you can make it work by putting the following lines in your `config/environments/production.rb`:
+As of Rails 3 ExceptionNotification-Redmine is used as a rack middleware, or in the environment you want it to run. In most cases you would want ExceptionNotification-Redmine to run on production. Thus, you can make it work by putting the following lines in your `/config/initializers` folder you can also add this to `config/environments/production.rb` however rails wipes this file when updating along with the fact that if you use git you risk adding your credentials or removing production.rb from the repo.:
 
 ```ruby
 Whatever::Application.config.middleware.use ExceptionNotification::Rack,
@@ -43,7 +51,7 @@ Whatever::Application.config.middleware.use ExceptionNotification::Rack,
   # fixed_version_id: create issues with the given fixed_version_id (aka target version id)
   # x_checksum_cf_id: custom field used to avoid creation of the same issue multiple times. You must use the DOM id assigned by Redmine to this field in the issue form. You can find it by creating an issue manually in your project and inspecting the HTML form, you should see something like name="issue[custom_field_values][19]", in this case the id would be 19. Make sure you set the custom field to be used as a filter
   # formatting: Redmine offers Markdown or Textile. Optional value. Will default to Markdown if anything else is entered other than textile. You will need to set this based on what you have in Redmine Administration -> Settings -> Text formatting
-  
+
 
   :redmine => {
     :host_url => "https://redmine.example.com",
@@ -66,7 +74,7 @@ Whatever::Application.config.middleware.use ExceptionNotification::Rack,
 ```
 ## Contributing
 
-1. Fork it ( https://github.com/Nuxos-Asia/exception_notification-redmine/fork )
+1. Fork it ( https://github.com/geocom/exception_notification-redmine/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Whatever::Application.config.middleware.use ExceptionNotification::Rack,
     :status_id => "1", # New
     :fixed_version_id => "1", # id of the issue target version on redmine
     :x_checksum_cf_id => "19", # DOM id in Redmine issue form
-    :formatting => "textile" #Optional defaults to Markdown if left out or any other type is input.
+    :formatting => "textile", #Optional defaults to Markdown if left out or any other type is input.
+    :x_hit_count_cf_id =>"20", #Optional if issue already exits it will update that issue with more information. If nil it will not update the custom field hit counter. DOM id in Redmine issue form
   }
 ```
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This Ruby gem is an extension of the [exception_notification gem](http://rubygem
 ## Fork notice.
 This fork exists as a updated version of the [http://rubygems.org/gems/exception_notification-redmine](http://rubygems.org/gems/exception_notification-redmine) gem.
 I have attempted to contact the original developer to add these changes however this has been unsuccessful.
-The devs have been inactive for a few years and the companies website is now dead so assuming the original project will not be maintained.
+The devs have been inactive for a few years and the companies website is now dead so assuming the original maintainers are no longer actively maintaining this gem
 
 As this is a gem I use I am looking at taking over development. At present there is no build on rubygems. You will need to install directly from this fork. Installation instructions have been updated to this end.
 
@@ -32,8 +32,10 @@ Or install it yourself as:
 ## Usage
 
 **IMPORTANT:** You must create a custom field named `x_checksum` in your Redmine project for the Redmine notifier to work properly
-**IMPORTANT FOR OPTIONAL SETTING:** To enable the hit counter you must add `x_hit_count` in your Redmine project for the Redmine notifier to work properly with updating an existing issue
-**IMPORTANT FOR OPTIONAL SETTING:** You must add a wontfix status if you enable reopening of closed issues.
+
+**IMPORTANT FOR OPTIONAL SETTING:** To enable the hit counter you must add `x_hit_count` in your Redmine project so existing issues can be updated with an occurrence number
+
+**IMPORTANT FOR OPTIONAL SETTING:** You must add a wontfix status in redmine to enable reopening of closed issues.
 
 As of Rails 3 ExceptionNotification-Redmine is used as a rack middleware, or in the environment you want it to run. In most cases you would want ExceptionNotification-Redmine to run on production. Thus, you can make it work by putting the following lines in your `/config/initializers` folder you can also add this to `config/environments/production.rb` however rails wipes this file when updating along with the fact that if you use git you risk adding your credentials or removing production.rb from the repo.:
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,12 @@ Whatever::Application.config.middleware.use ExceptionNotification::Rack,
   # fixed_version_id: create issues with the given fixed_version_id (aka target version id)
   # x_checksum_cf_id: custom field used to avoid creation of the same issue multiple times. You must use the DOM id assigned by Redmine to this field in the issue form. You can find it by creating an issue manually in your project and inspecting the HTML form, you should see something like name="issue[custom_field_values][19]", in this case the id would be 19. Make sure you set the custom field to be used as a filter
   # formatting: Redmine offers Markdown or Textile. Optional value. Will default to Markdown if anything else is entered other than textile. You will need to set this based on what you have in Redmine Administration -> Settings -> Text formatting
+  
 
   :redmine => {
     :host_url => "https://redmine.example.com",
-    :issues_url => "issues.json",
+    :issues_url => "issues", #Note Depreciation warning for updating code. Old versions included the format within the issues url. However in order to update issues the format needs to proceed the ticket number. For now the old formatting will continue to work provided that you have not added x_hit_count_cf_id to your config. Please update to include request_format as this fallback may be removed in a future revision of this gem to save on code size.
+    :request_format => "json",
     :issues_prefix => "[Error]",
     :api_key => "123456",
     :project_id => "test-project",
@@ -58,6 +60,8 @@ Whatever::Application.config.middleware.use ExceptionNotification::Rack,
     :x_checksum_cf_id => "19", # DOM id in Redmine issue form
     :formatting => "textile", #Optional defaults to Markdown if left out or any other type is input.
     :x_hit_count_cf_id =>"20", #Optional if issue already exits it will update that issue with more information. If nil it will not update the custom field hit counter. DOM id in Redmine issue form
+    :add_note_on_update  => true, #Optional if issue already exits it will update that issue and add a note to the issue with the description. Requires x_hit_count_cf_id to be set first
+    :reopen_issue_if_closed => [1, [3, 5, 6], 8] #Optional, will reopen issue if closed. to setup put the id values for your statuses [reopen to, [array of closed statuses. if any of these the issue will be reopened], wontfix]
   }
 ```
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Whatever::Application.config.middleware.use ExceptionNotification::Rack,
   # priority_id: create issues with the given priority_id
   # status_id: create issues with the given status_id
   # fixed_version_id: create issues with the given fixed_version_id (aka target version id)
-  # x_checksum_cf_id: custom field used to avoid creation of the same issue multiple times. You must use the DOM id assigned by Redmine to this field in the issue form. You can find it by creating an issue manually in your project and inspecting the HTML form, you should see something like name="issue[custom_field_values][19]", in this case the id would be 19.
+  # x_checksum_cf_id: custom field used to avoid creation of the same issue multiple times. You must use the DOM id assigned by Redmine to this field in the issue form. You can find it by creating an issue manually in your project and inspecting the HTML form, you should see something like name="issue[custom_field_values][19]", in this case the id would be 19. Make sure you set the custom field to be used as a filter
+  # formatting: Redmine offers Markdown or Textile. Optional value. Will default to Markdown if anything else is entered other than textile. You will need to set this based on what you have in Redmine Administration -> Settings -> Text formatting
 
   :redmine => {
     :host_url => "https://redmine.example.com",
@@ -54,7 +55,8 @@ Whatever::Application.config.middleware.use ExceptionNotification::Rack,
     :priority_id => "6", # Urgent
     :status_id => "1", # New
     :fixed_version_id => "1", # id of the issue target version on redmine
-    :x_checksum_cf_id => "19" # DOM id in Redmine issue form
+    :x_checksum_cf_id => "19", # DOM id in Redmine issue form
+    :formatting => "textile" #Optional defaults to Markdown if left out or any other type is input.
   }
 ```
 ## Contributing

--- a/exception_notification-redmine.gemspec
+++ b/exception_notification-redmine.gemspec
@@ -6,12 +6,12 @@ require 'exception_notification/redmine/version'
 Gem::Specification.new do |s|
   s.name = 'exception_notification-redmine'
   s.version       = ExceptionNotification::Redmine::VERSION
-  s.authors = ["Richard Piacentini", "Suttipong Wisittanakorn"]
+  s.authors = ["Geoff Evans", "Richard Piacentini", "Suttipong Wisittanakorn"]
   s.date = "2017-04-18"
   s.summary = "This gem add a Redmine notifier to Exception Notification"
   s.description = "This Ruby gem is an extension of the exception_notification gem to support creating issues in Redmine"
   s.homepage = "https://github.com/Nuxos-Asia/exception_notification-redmine"
-  s.email = ["richard.piacentini@nuxos.asia", "safe@nuxos.asia"]
+  s.email = ["gbeevans@gmail.com", "richard.piacentini@nuxos.asia", "safe@nuxos.asia"]
   s.license = "MIT"
 
   s.post_install_message = "*** Please read the README.MD file to setup the Redmine Notifier."

--- a/lib/exception_notification/redmine/version.rb
+++ b/lib/exception_notification/redmine/version.rb
@@ -1,5 +1,5 @@
 module ExceptionNotification
   module Redmine
-    VERSION = "0.3.2"
+    VERSION = "0.3.3"
   end
 end

--- a/lib/exception_notifier/redmine/redmine.rb
+++ b/lib/exception_notifier/redmine/redmine.rb
@@ -114,7 +114,7 @@ module ExceptionNotifier
         puts "Hit count option not specified. Will not update"
       else
         hit_count = 0
-        old_issue[0]["custom_fields"][0].each do |custom|
+        old_issues[0]["custom_fields"][0].each do |custom|
           if custom[:id] == @config[:x_hit_count_cf_id]
             hit_count = custom[:value].to_i + 1
             break

--- a/lib/exception_notifier/redmine/redmine.rb
+++ b/lib/exception_notifier/redmine/redmine.rb
@@ -114,7 +114,7 @@ module ExceptionNotifier
         puts "Hit count option not specified. Will not update"
       else
         hit_count = 0
-        old_issues[0]["custom_fields"][0].each do |custom|
+        old_issue[0]["custom_fields"][0].each do |custom|
           if custom[:id] == @config[:x_hit_count_cf_id]
             hit_count = custom[:value].to_i + 1
             break

--- a/lib/exception_notifier/redmine/redmine.rb
+++ b/lib/exception_notifier/redmine/redmine.rb
@@ -23,8 +23,7 @@ module ExceptionNotifier
         issue = compose_issue
         old_issues = issue_exist?(issue)
         if old_issues["total_count"] > 0
-          puts old_issues
-          update_existing(issue, old_issues)
+          update_existing(old_issues)
         else
           create_issue(issue)
         end
@@ -86,12 +85,16 @@ module ExceptionNotifier
     def issues_url(params = {})
       default_params = { :key => @config[:api_key] }
       encoded_params = URI.encode_www_form(default_params.merge(params))
-      "#{@config[:host_url]}/#{@config[:issues_url]}?#{encoded_params}"
+      if not @config[:request_format] == nil
+        "#{@config[:host_url]}/#{@config[:issues_url]}.#{@config[:request_format]}?#{encoded_params}"
+      else
+        "#{@config[:host_url]}/#{@config[:issues_url]}?#{encoded_params}"
+      end
     end
     def update_url(params = {}, issue_id)
       default_params = { :key => @config[:api_key] }
       encoded_params = URI.encode_www_form(default_params.merge(params))
-      "#{@config[:host_url]}/#{@config[:issues_url]}/#{issue_id}?#{encoded_params}"
+      "#{@config[:host_url]}/#{@config[:issues_url]}/#{issue_id}.#{@config[:request_format]}?#{encoded_params}"
     end
     def create_issue(issue)
       options = { :body => { :issue => issue }.to_json,
@@ -102,31 +105,46 @@ module ExceptionNotifier
     def issue_exist?(issue)
       x_checksum = issue[:custom_fields][0][:value]
       response = ::HTTParty.send(:get, issues_url("project_id" => @config[:project_id],
-                                                  "cf_#{@config[:x_checksum_cf_id]}" => x_checksum))
+                                                  "cf_#{@config[:x_checksum_cf_id]}" => x_checksum,
+                                                  "status_id" => "*"))
       if response.nil? || response["total_count"].nil?
         Rails.logger.debug "Received unexpected response: #{response.inspect}"
         raise "Unexpected Response"
       end
       return response
     end
-    def update_existing(issue, old_issue)
+    def update_existing(old_issue)
       if @config[:x_hit_count_cf_id] == nil or @config[:x_hit_count_cf_id] == ""
         puts "Hit count option not specified. Will not update"
       else
         hit_count = 0
-        puts old_issue[0]["custom_fields"][0]
-        old_issue[0]["custom_fields"][0].each do |custom|
-          if custom[:id] == @config[:x_hit_count_cf_id]
-            hit_count = custom[:value].to_i + 1
+        old_issue["issues"][0]["custom_fields"].each do |custom|
+          if custom["id"] == @config[:x_hit_count_cf_id].to_i
+            hit_count = custom["value"].to_i + 1
             break
           end
         end
         issue = {}
-        issue[:custom_fields] = [{ :id    => @config[:x_hit_count_cf_id],
-                                   :value => hit_count}]
+        old_issue["issues"][0]["status"]["id"]
+        if not (@config[:reopen_issue_if_closed] == nil or @config[:reopen_issue_if_closed] == "")
+          if @config[:reopen_issue_if_closed][1].include?(old_issue["issues"][0]["status"]["id"]) == true
+            issue[:status_id] = @config[:reopen_issue_if_closed][0]
+          elsif @config[:reopen_issue_if_closed][2] == old_issue["issues"][0]["status"]["id"].to_i
+            puts "WontFix Set. Skipping Updating"
+            return "WONTFIX"
+          end
+        end
+
+
+        if @config[:add_note_on_update] == true
+          issue[:notes] = compose_description
+        end
+        issue[:custom_fields] = [{ :value => hit_count,
+                                   :id    => @config[:x_hit_count_cf_id]}]
+
         options = { :body => { :issue => issue }.to_json,
                     :headers => { "Content-Type" => "application/json" } }
-        ::HTTParty.send(:put, update_url, options)
+        ::HTTParty.send(:put, update_url({}, old_issue["issues"][0]["id"]), options)
       end
     end
     def encode_subject(subject)

--- a/lib/exception_notifier/redmine/redmine.rb
+++ b/lib/exception_notifier/redmine/redmine.rb
@@ -61,7 +61,11 @@ module ExceptionNotifier
     end
 
     def compose_description
-      template_path = "#{File.dirname(__FILE__)}/views/exception_notifier/issue.text.erb"
+      if @config[:formatting] == "textile"
+        template_path = "#{File.dirname(__FILE__)}/views/exception_notifier/issue.text.erb"
+      else
+        template_path = "#{File.dirname(__FILE__)}/views/exception_notifier/issue.md.text.erb"
+      end
       template = File.open(template_path, "r").read
       ERB.new(template, nil, '-').result(binding)
     end

--- a/lib/exception_notifier/redmine/redmine.rb
+++ b/lib/exception_notifier/redmine/redmine.rb
@@ -114,6 +114,7 @@ module ExceptionNotifier
         puts "Hit count option not specified. Will not update"
       else
         hit_count = 0
+        puts old_issue[0]["custom_fields"][0]
         old_issue[0]["custom_fields"][0].each do |custom|
           if custom[:id] == @config[:x_hit_count_cf_id]
             hit_count = custom[:value].to_i + 1

--- a/lib/exception_notifier/redmine/views/exception_notifier/issue.md.text.erb
+++ b/lib/exception_notifier/redmine/views/exception_notifier/issue.md.text.erb
@@ -1,0 +1,35 @@
+<%= @exception.class.to_s =~ /^[aeiou]/i ? 'An' : 'A' %> <%= @exception.class %> occurred in <%= @kontroller.controller_name %>#<%= @kontroller.action_name %>:
+
+<%= @exception.message %>
+<%= @backtrace.first %>
+
+# Request
+
+* URL        : <%= @request.url %>
+* HTTP Method: <%= @request.request_method %>
+* IP address : <%= @request.remote_ip %>
+* Parameters : <%= @request.filtered_parameters.inspect %>
+* Timestamp  : <%= Time.current %>
+* Server : <%= Socket.gethostname %>
+<% if defined?(Rails) -%>
+* Rails root : <%= Rails.root %>
+<% end -%>
+* Process: <%= $$ %>
+
+# Session
+
+* session id: <%= @request.ssl? ? "[FILTERED]" : (@request.session['session_id'] || (@request.env["rack.session.options"] && @request.env["rack.session.options"][:id])).inspect %>
+* data: <%= PP.pp(@request.session.to_hash, "") %>
+
+# Environment
+
+<% filtered_env = @request.filtered_env -%>
+<% max = filtered_env.keys.map(&:to_s).max { |a, b| a.length <=> b.length } -%>
+<% filtered_env.keys.map(&:to_s).sort.each do |key| -%>
+<% inspect_object = filtered_env[key].is_a?(Hash) || filtered_env[key].is_a?(Array) ? filtered_env[key].inspect : filtered_env[key].to_s -%>
+* <%= "%-*s: %s" % [max.length, key, inspect_object] %>
+<% end -%>
+
+# Backtrace
+
+<%= @backtrace.join("\n") %>


### PR DESCRIPTION
Add Markdown and the formatting option in config it will default to markdown if nothing is entered or the value is not set as Textile(Markdown now being the more common option this felt like the correct option)

Also adds a note that the x_checksum_cf_id needs to be set as use as a filter.